### PR TITLE
Name pods after test suite and definition

### DIFF
--- a/config/crds/testing_v1alpha1_clustertestsuite.yaml
+++ b/config/crds/testing_v1alpha1_clustertestsuite.yaml
@@ -55,8 +55,7 @@ spec:
               properties:
                 matchLabels:
                   description: Find test definitions by it's labels. TestDefinition
-                    should have AT LEAST one label listed here to be executed. Label
-                    value is irrelevant.
+                    should have AT LEAST one label listed here to be executed.
                   items:
                     type: string
                   type: array

--- a/pkg/fetcher/pod_test.go
+++ b/pkg/fetcher/pod_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kyma-incubator/octopus/pkg/scheduler"
-
 	"github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
 	"github.com/kyma-incubator/octopus/pkg/fetcher"
 	"github.com/kyma-incubator/octopus/pkg/fetcher/automock"
@@ -22,9 +20,13 @@ import (
 
 func TestGetPodsForSuite(t *testing.T) {
 	// GIVEN
+	givenSuite := v1alpha1.ClusterTestSuite{ObjectMeta: v12.ObjectMeta{
+		Name: "test-all-suite",
+	}}
+
 	givenPod := v1.Pod{
 		ObjectMeta: v12.ObjectMeta{
-			Name:      fmt.Sprintf("%s%d", scheduler.TestingPodGeneratedName, 1),
+			Name:      fmt.Sprintf("%s-%d", givenSuite.Name, 1),
 			Namespace: "aaa",
 			Labels: map[string]string{
 				v1alpha1.LabelKeyCreatedByOctopus: "true",
@@ -32,10 +34,6 @@ func TestGetPodsForSuite(t *testing.T) {
 			},
 		},
 	}
-
-	givenSuite := v1alpha1.ClusterTestSuite{ObjectMeta: v12.ObjectMeta{
-		Name: "test-all-suite",
-	}}
 
 	mockReader := &automock.Reader{}
 	defer mockReader.AssertExpectations(t)

--- a/pkg/fetcher/pod_test.go
+++ b/pkg/fetcher/pod_test.go
@@ -26,7 +26,7 @@ func TestGetPodsForSuite(t *testing.T) {
 
 	givenPod := v1.Pod{
 		ObjectMeta: v12.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%d", givenSuite.Name, 1),
+			Name:      fmt.Sprintf("%s-my-test-%d", givenSuite.Name, 1),
 			Namespace: "aaa",
 			Labels: map[string]string{
 				v1alpha1.LabelKeyCreatedByOctopus: "true",

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
 	"github.com/pkg/errors"
@@ -75,7 +76,7 @@ func (s *Service) startPod(suite v1alpha1.ClusterTestSuite, def v1alpha1.TestDef
 	p.Labels = def.Spec.Template.Labels
 	p.Annotations = def.Spec.Template.Annotations
 
-	p.GenerateName = TestingPodGeneratedName
+	p.GenerateName = fmt.Sprintf("%s-", suite.Name)
 	p.Namespace = def.Namespace
 
 	if p.Labels == nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -13,10 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	TestingPodGeneratedName = "octopus-testing-pod-"
-)
-
 //go:generate go run ./../../vendor/github.com/vektra/mockery/cmd/mockery/mockery.go -name=StatusProvider -output=automock -outpkg=automock -case=underscore
 type StatusProvider interface {
 	GetNextToSchedule(suite v1alpha1.ClusterTestSuite) *v1alpha1.TestResult

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -72,7 +72,7 @@ func (s *Service) startPod(suite v1alpha1.ClusterTestSuite, def v1alpha1.TestDef
 	p.Labels = def.Spec.Template.Labels
 	p.Annotations = def.Spec.Template.Annotations
 
-	p.GenerateName = fmt.Sprintf("%s-", suite.Name)
+	p.GenerateName = fmt.Sprintf("%s-%s-", suite.Name, def.Name)
 	p.Namespace = def.Namespace
 
 	if p.Labels == nil {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -52,7 +52,7 @@ func TestTryScheduleHappyPath(t *testing.T) {
 	require.NoError(t, fakeCli.List(context.TODO(), &client.ListOptions{Namespace: "test-namespace"}, &actualPodList))
 	assert.Contains(t, actualPodList.Items, *pod)
 
-	assert.Equal(t, "octopus-testing-pod-0", pod.Name)
+	assert.Equal(t, uninitializedSuite.Name+"-0", pod.Name)
 	assert.Equal(t, "test-namespace", pod.Namespace)
 	assert.Len(t, pod.Spec.Containers, 1)
 	assert.Equal(t, "alpine", pod.Spec.Containers[0].Image)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -52,7 +52,7 @@ func TestTryScheduleHappyPath(t *testing.T) {
 	require.NoError(t, fakeCli.List(context.TODO(), &client.ListOptions{Namespace: "test-namespace"}, &actualPodList))
 	assert.Contains(t, actualPodList.Items, *pod)
 
-	assert.Equal(t, uninitializedSuite.Name+"-0", pod.Name)
+	assert.Equal(t, uninitializedSuite.Name+"-"+givenTd.Name+"-0", pod.Name)
 	assert.Equal(t, "test-namespace", pod.Namespace)
 	assert.Len(t, pod.Spec.Containers, 1)
 	assert.Equal(t, "alpine", pod.Spec.Containers[0].Image)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Newly created pods are named after TestSuite they belong to.
- Add generated CRD.

Thanks to that test pods are easier to identify visually.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
