### PR TITLE
Add label filtering to CTS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1003,6 +1003,7 @@
     "k8s.io/apimachinery/pkg/selection",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/rand",
+    "k8s.io/apimachinery/pkg/util/uuid",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1003,7 +1003,6 @@
     "k8s.io/apimachinery/pkg/selection",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/rand",
-    "k8s.io/apimachinery/pkg/util/uuid",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",

--- a/config/crds/testing_v1alpha1_clustertestsuite.yaml
+++ b/config/crds/testing_v1alpha1_clustertestsuite.yaml
@@ -53,10 +53,10 @@ spec:
               description: Decide which tests to execute. If not provided execute
                 all tests
               properties:
-                matchLabels:
-                  description: 'Find test definitions by its labels. TestDefinition
-                    should match AT LEAST one expression listed here to be executed.
-                    For a complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811'
+                matchLabelExpressions:
+                  description: 'Find test definitions by their labels. TestDefinition
+                    must match AT LEAST one expression listed here to be executed.
+                    For the complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811'
                   items:
                     type: string
                   type: array

--- a/config/crds/testing_v1alpha1_clustertestsuite.yaml
+++ b/config/crds/testing_v1alpha1_clustertestsuite.yaml
@@ -56,7 +56,7 @@ spec:
                 matchLabelExpressions:
                   description: 'Find test definitions by their labels. TestDefinition
                     must match AT LEAST one expression listed here to be executed.
-                    For the complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811'
+                    For the complete grammar see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
                   items:
                     type: string
                   type: array

--- a/config/crds/testing_v1alpha1_clustertestsuite.yaml
+++ b/config/crds/testing_v1alpha1_clustertestsuite.yaml
@@ -54,8 +54,9 @@ spec:
                 all tests
               properties:
                 matchLabels:
-                  description: Find test definitions by it's labels. TestDefinition
-                    should have AT LEAST one label listed here to be executed.
+                  description: 'Find test definitions by its labels. TestDefinition
+                    should match AT LEAST one expression listed here to be executed.
+                    For a complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811'
                   items:
                     type: string
                   type: array

--- a/config/samples/advanced/testsuite-select-by-labels.yaml
+++ b/config/samples/advanced/testsuite-select-by-labels.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: testing.kyma-project.io/v1alpha1
+kind: ClusterTestSuite
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: testsuite-selected-by-labels
+spec:
+  count: 1
+  selectors:
+    matchLabelExpressions:
+      - "test-duration!=long" # do not execute long running tests
+      - "component in (frontend, backend)" # execute all tests for frontend and backend, regardless of their execution time.
+

--- a/config/samples/advanced/testsuite-select-by-labels.yaml
+++ b/config/samples/advanced/testsuite-select-by-labels.yaml
@@ -9,6 +9,7 @@ spec:
   count: 1
   selectors:
     matchLabelExpressions:
-      - "test-duration!=long" # do not execute long running tests
-      - "component in (frontend, backend)" # execute all tests for frontend and backend, regardless of their execution time.
+      # This example executes all not long tests for frontend and all tests for backend
+      - component=frontend,test-duration!=long
+      - component=backend
 

--- a/docs/crd-cluster-test-suite.md
+++ b/docs/crd-cluster-test-suite.md
@@ -31,7 +31,7 @@ This table lists all the possible parameters of a given resource together with t
 | **metadata.name** |    **YES**   | Specifies the name of the CR. |
 | **spec.selectors** | **NO** | Defines which tests should be executed. You can define tests by specifying their names or labels. Selectors are additive. If not defined, all tests from all Namespaces are executed.
 | **spec.selectors.matchNames** | **NO** | Lists TestDefinitions to execute. For every element on the list, specify **name** and **namespace** that refers to a TestDefinition. |
-| **spec.selectors.matchLabels** | **NO** | Lists labels that match labels of TestDefinitions to execute. A TestDefinition is selected if at least one label matches. This feature is not yet implemented. | 
+| **spec.selectors.matchLabelExpressions** | **NO** | Lists of label expressions that match labels of TestDefinitions to execute. A TestDefinition is selected if at least one label expression matches. For the complete grammar see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels | 
 | **spec.concurrency** | **NO** | Defines how many tests can be executed at the same time, which depends on cluster size and its load. The default value is `1`.
 | **spec.suiteTimeout** | **NO** | Defines the maximal suite duration after which test executions are interrupted and marked as **Failed**. The default value is one hour. This feature is not yet implemented. 
 | **spec.count** | **NO** | Defines how many times every test should be executed. **Spec.Count** and **Spec.MaxRetries** are mutually exclusive. The default value is `1`.  

--- a/docs/crd-cluster-test-suite.md
+++ b/docs/crd-cluster-test-suite.md
@@ -31,7 +31,7 @@ This table lists all the possible parameters of a given resource together with t
 | **metadata.name** |    **YES**   | Specifies the name of the CR. |
 | **spec.selectors** | **NO** | Defines which tests should be executed. You can define tests by specifying their names or labels. Selectors are additive. If not defined, all tests from all Namespaces are executed.
 | **spec.selectors.matchNames** | **NO** | Lists TestDefinitions to execute. For every element on the list, specify **name** and **namespace** that refers to a TestDefinition. |
-| **spec.selectors.matchLabelExpressions** | **NO** | Lists of label expressions that match labels of TestDefinitions to execute. A TestDefinition is selected if at least one label expression matches. For the complete grammar see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels | 
+| **spec.selectors.matchLabelExpressions** | **NO** | Lists label expressions that match labels of TestDefinitions to execute. A TestDefinition is selected if at least one label expression matches. See [this](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels) document for more details. | 
 | **spec.concurrency** | **NO** | Defines how many tests can be executed at the same time, which depends on cluster size and its load. The default value is `1`.
 | **spec.suiteTimeout** | **NO** | Defines the maximal suite duration after which test executions are interrupted and marked as **Failed**. The default value is one hour. This feature is not yet implemented. 
 | **spec.count** | **NO** | Defines how many times every test should be executed. **Spec.Count** and **Spec.MaxRetries** are mutually exclusive. The default value is `1`.  

--- a/pkg/apis/testing/v1alpha1/testsuite_types.go
+++ b/pkg/apis/testing/v1alpha1/testsuite_types.go
@@ -108,9 +108,10 @@ type TestSuiteSpec struct {
 type TestsSelector struct {
 	// Find test definitions by it's name
 	MatchNames []TestDefReference `json:"matchNames,omitempty"`
-	// Find test definitions by it's labels.
-	// TestDefinition should have AT LEAST one label listed here to be executed.
-	MatchLabels []string `json:"matchLabels,omitempty"`
+	// Find test definitions by its labels.
+	// TestDefinition should match AT LEAST one expression listed here to be executed.
+	// For a complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811
+	MatchLabelExpressions []string `json:"matchLabels,omitempty"`
 }
 
 type TestDefReference struct {

--- a/pkg/apis/testing/v1alpha1/testsuite_types.go
+++ b/pkg/apis/testing/v1alpha1/testsuite_types.go
@@ -160,5 +160,5 @@ func init() {
 }
 
 func (in ClusterTestSuite) HasSelector() bool {
-	return len(s.Spec.Selectors.MatchNames) > 0 || len(s.Spec.Selectors.MatchLabelExpressions) > 0
+	return len(in.Spec.Selectors.MatchNames) > 0 || len(in.Spec.Selectors.MatchLabelExpressions) > 0
 }

--- a/pkg/apis/testing/v1alpha1/testsuite_types.go
+++ b/pkg/apis/testing/v1alpha1/testsuite_types.go
@@ -110,7 +110,7 @@ type TestsSelector struct {
 	MatchNames []TestDefReference `json:"matchNames,omitempty"`
 	// Find test definitions by their labels.
 	// TestDefinition must match AT LEAST one expression listed here to be executed.
-	// For the complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811
+	// For the complete grammar see: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	MatchLabelExpressions []string `json:"matchLabelExpressions,omitempty"`
 }
 

--- a/pkg/apis/testing/v1alpha1/testsuite_types.go
+++ b/pkg/apis/testing/v1alpha1/testsuite_types.go
@@ -158,3 +158,7 @@ type TestExecution struct {
 func init() {
 	SchemeBuilder.Register(&ClusterTestSuite{}, &ClusterTestSuiteList{})
 }
+
+func (in ClusterTestSuite) HasSelector() bool {
+	return len(s.Spec.Selectors.MatchNames) > 0 || len(s.Spec.Selectors.MatchLabelExpressions) > 0
+}

--- a/pkg/apis/testing/v1alpha1/testsuite_types.go
+++ b/pkg/apis/testing/v1alpha1/testsuite_types.go
@@ -108,10 +108,10 @@ type TestSuiteSpec struct {
 type TestsSelector struct {
 	// Find test definitions by it's name
 	MatchNames []TestDefReference `json:"matchNames,omitempty"`
-	// Find test definitions by its labels.
-	// TestDefinition should match AT LEAST one expression listed here to be executed.
-	// For a complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811
-	MatchLabelExpressions []string `json:"matchLabels,omitempty"`
+	// Find test definitions by their labels.
+	// TestDefinition must match AT LEAST one expression listed here to be executed.
+	// For the complete grammar see: https://github.com/kubernetes/apimachinery/blob/master/pkg/labels/selector.go#L811
+	MatchLabelExpressions []string `json:"matchLabelExpressions,omitempty"`
 }
 
 type TestDefReference struct {

--- a/pkg/apis/testing/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/testing/v1alpha1/zz_generated.deepcopy.go
@@ -311,8 +311,8 @@ func (in *TestsSelector) DeepCopyInto(out *TestsSelector) {
 		*out = make([]TestDefReference, len(*in))
 		copy(*out, *in)
 	}
-	if in.MatchLabels != nil {
-		in, out := &in.MatchLabels, &out.MatchLabels
+	if in.MatchLabelExpressions != nil {
+		in, out := &in.MatchLabelExpressions, &out.MatchLabelExpressions
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/controller/testsuite/testsuite_controller_test.go
+++ b/pkg/controller/testsuite/testsuite_controller_test.go
@@ -503,7 +503,7 @@ type mockPodReconciler struct {
 	cli client.Client
 	// mutex protecting access to applied changes slice
 	mtx sync.Mutex
-	// chronologically list of pod changes. Use getter to access it autside the struct
+	// chronologically list of pod changes. Use getter to access it outside the struct
 	appliedChanges                         []podStatusChanges
 	enforceNumberOfConcurrentlyRunningPods int
 	reconcileAfter                         time.Duration

--- a/pkg/controller/testsuite/testsuite_controller_test.go
+++ b/pkg/controller/testsuite/testsuite_controller_test.go
@@ -483,8 +483,8 @@ func (r *mockPodReconciler) getLogger() logr.Logger {
 
 func startMockPodController(mgr manager.Manager, enforceConcurrentlyRunningPods int) (*mockPodReconciler, error) {
 	pr := &mockPodReconciler{
-		cli: mgr.GetClient(),
-		mtx: sync.Mutex{},
+		cli:                                    mgr.GetClient(),
+		mtx:                                    sync.Mutex{},
 		enforceNumberOfConcurrentlyRunningPods: enforceConcurrentlyRunningPods,
 		reconcileAfter:                         time.Millisecond * 100,
 	}

--- a/pkg/fetcher/definition.go
+++ b/pkg/fetcher/definition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/kyma-incubator/octopus/pkg/humanerr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
@@ -22,12 +23,26 @@ type Definition struct {
 	reader client.Reader
 }
 
+type uniqueTestDefinitions map[types.UID]v1alpha1.TestDefinition
+
 func (s *Definition) FindMatching(suite v1alpha1.ClusterTestSuite) ([]v1alpha1.TestDefinition, error) {
 	ctx := context.TODO()
-	if len(suite.Spec.Selectors.MatchNames) > 0 {
-		return s.findByNames(ctx, suite)
+	acc := make(uniqueTestDefinitions)
+
+	err := s.findByNames(ctx, suite, &acc)
+	if err != nil {
+		return nil, err
 	}
-	// TODO(aszecowka) later so far we return all test definitions for all namespaces (https://github.com/kyma-incubator/octopus/issues/7)
+
+	err = s.findByLabelExpressions(ctx, suite, &acc)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(acc) > 0 {
+		return acc.toList(), nil
+	}
+
 	var list v1alpha1.TestDefinitionList
 	if err := s.reader.List(ctx, &client.ListOptions{Namespace: ""}, &list); err != nil {
 		return nil, errors.Wrap(err, "while listing test definitions")
@@ -35,8 +50,7 @@ func (s *Definition) FindMatching(suite v1alpha1.ClusterTestSuite) ([]v1alpha1.T
 	return list.Items, nil
 }
 
-func (s *Definition) findByNames(ctx context.Context, suite v1alpha1.ClusterTestSuite) ([]v1alpha1.TestDefinition, error) {
-	var list []v1alpha1.TestDefinition
+func (s *Definition) findByNames(ctx context.Context, suite v1alpha1.ClusterTestSuite, acc *uniqueTestDefinitions) error {
 	for _, tRef := range suite.Spec.Selectors.MatchNames {
 		def := v1alpha1.TestDefinition{}
 		err := s.reader.Get(ctx, types.NamespacedName{Name: tRef.Name, Namespace: tRef.Namespace}, &def)
@@ -44,11 +58,36 @@ func (s *Definition) findByNames(ctx context.Context, suite v1alpha1.ClusterTest
 		switch {
 		case err == nil:
 		case k8serrors.IsNotFound(err):
-			return nil, humanerr.NewError(wrappedErr, fmt.Sprintf("Test Definition [name: %s, namespace: %s] does not exist", tRef.Name, tRef.Namespace))
+			return humanerr.NewError(wrappedErr, fmt.Sprintf("Test Definition [name: %s, namespace: %s] does not exist", tRef.Name, tRef.Namespace))
 		default:
-			return nil, humanerr.NewError(wrappedErr, "Internal error")
+			return humanerr.NewError(wrappedErr, "Internal error")
 		}
+		(*acc)[def.UID] = def
+	}
+	return nil
+}
+
+func (s *Definition) findByLabelExpressions(ctx context.Context, suite v1alpha1.ClusterTestSuite, acc *uniqueTestDefinitions) error {
+	for _, expr := range suite.Spec.Selectors.MatchLabelExpressions {
+		selector, err := labels.Parse(expr)
+		if err != nil {
+			return errors.Wrapf(err, "while parsing label expression [expression: %s]", expr)
+		}
+		var list v1alpha1.TestDefinitionList
+		if err := s.reader.List(ctx, &client.ListOptions{LabelSelector: selector}, &list); err != nil {
+			return errors.Wrapf(err, "while fetching test definition from selector [expression: %s]", expr)
+		}
+		for _, def := range list.Items {
+			(*acc)[def.UID] = def
+		}
+	}
+	return nil
+}
+
+func (m uniqueTestDefinitions) toList() []v1alpha1.TestDefinition {
+	var list []v1alpha1.TestDefinition
+	for _, def := range m {
 		list = append(list, def)
 	}
-	return list, nil
+	return list
 }

--- a/pkg/fetcher/definition_test.go
+++ b/pkg/fetcher/definition_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/kyma-incubator/octopus/pkg/humanerr"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 
@@ -41,18 +42,21 @@ func TestFindMatching(t *testing.T) {
 		// GIVEN
 		testA := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
 				Name:      "test-a",
 				Namespace: "test-a",
 			},
 		}
 		testB := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
 				Name:      "test-b",
 				Namespace: "test-b",
 			},
 		}
 		testC := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
 				Name:      "test-c",
 				Namespace: "test-c",
 			},
@@ -87,6 +91,133 @@ func TestFindMatching(t *testing.T) {
 
 	})
 
+	t.Run("return tests selected by label expressions", func(t *testing.T) {
+		// GIVEN
+		testA := &v1alpha1.TestDefinition{
+			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
+				Name:      "test-a",
+				Namespace: "test-a",
+				Labels: map[string]string{
+					"test": "true",
+				},
+			},
+		}
+		testB := &v1alpha1.TestDefinition{
+			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
+				Name:      "test-b",
+				Namespace: "test-b",
+				Labels: map[string]string{
+					"test": "false",
+				},
+			},
+		}
+		testC := &v1alpha1.TestDefinition{
+			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
+				Name:      "test-c",
+				Namespace: "test-c",
+				Labels: map[string]string{
+					"other": "123",
+				},
+			},
+		}
+
+		fakeCli := fake.NewFakeClientWithScheme(sch,
+			testA, testB, testC,
+		)
+		mockReader := &mockListReader{
+			fakeCli: fakeCli,
+			listResults: [][]v1alpha1.TestDefinition{
+				{*testC},
+				{*testA},
+			},
+		}
+		service := fetcher.NewForDefinition(mockReader)
+		// WHEN
+		out, err := service.FindMatching(v1alpha1.ClusterTestSuite{
+			Spec: v1alpha1.TestSuiteSpec{
+				Selectors: v1alpha1.TestsSelector{
+					MatchLabelExpressions: []string{
+						"other",
+						"test=true",
+					},
+				},
+			},
+		})
+		// THEN
+		require.NoError(t, err)
+		assert.Len(t, out, 2)
+		assert.Contains(t, out, *testA)
+		assert.Contains(t, out, *testC)
+	})
+
+	t.Run("return tests returns unique results", func(t *testing.T) {
+		// GIVEN
+		testA := &v1alpha1.TestDefinition{
+			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
+				Name:      "test-a",
+				Namespace: "test-a",
+				Labels: map[string]string{
+					"test": "true",
+				},
+			},
+		}
+		testB := &v1alpha1.TestDefinition{
+			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
+				Name:      "test-b",
+				Namespace: "test-b",
+				Labels: map[string]string{
+					"test": "false",
+				},
+			},
+		}
+		testC := &v1alpha1.TestDefinition{
+			ObjectMeta: v1.ObjectMeta{
+				UID:       uuid.NewUUID(),
+				Name:      "test-c",
+				Namespace: "test-c",
+				Labels: map[string]string{
+					"other": "123",
+				},
+			},
+		}
+
+		fakeCli := fake.NewFakeClientWithScheme(sch,
+			testA, testB, testC,
+		)
+		mockReader := &mockListReader{
+			fakeCli: fakeCli,
+			listResults: [][]v1alpha1.TestDefinition{
+				{*testA},
+			},
+		}
+		service := fetcher.NewForDefinition(mockReader)
+		// WHEN
+		out, err := service.FindMatching(v1alpha1.ClusterTestSuite{
+			Spec: v1alpha1.TestSuiteSpec{
+				Selectors: v1alpha1.TestsSelector{
+					MatchNames: []v1alpha1.TestDefReference{
+						{
+							Name:      "test-a",
+							Namespace: "test-a",
+						},
+					},
+					MatchLabelExpressions: []string{
+						"test=true",
+					},
+				},
+			},
+		})
+		// THEN
+		require.NoError(t, err)
+		assert.Len(t, out, 1)
+		assert.Contains(t, out, *testA)
+	})
+
 	t.Run("return error if test selected by name does not exist", func(t *testing.T) {
 		// GIVEN
 		fakeCli := fake.NewFakeClientWithScheme(sch)
@@ -113,7 +244,7 @@ func TestFindMatching(t *testing.T) {
 
 	t.Run("return internal error when fetching selected tests failed", func(t *testing.T) {
 		// GIVEN
-		errClient := &mockErrReader{err:errors.New("some error")}
+		errClient := &mockErrReader{err: errors.New("some error")}
 		service := fetcher.NewForDefinition(errClient)
 
 		// WHEN
@@ -149,4 +280,21 @@ func (m *mockErrReader) Get(ctx context.Context, key client.ObjectKey, obj runti
 
 func (m *mockErrReader) List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
 	return m.err
+}
+
+type mockListReader struct {
+	fakeCli     client.Reader
+	listResults [][]v1alpha1.TestDefinition
+	calls       uint
+}
+
+func (m *mockListReader) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	return m.fakeCli.Get(ctx, key, obj)
+}
+
+func (m *mockListReader) List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
+	result := m.listResults[m.calls]
+	m.calls++
+	list.(*v1alpha1.TestDefinitionList).Items = append(list.(*v1alpha1.TestDefinitionList).Items, result...)
+	return nil
 }

--- a/pkg/fetcher/definition_test.go
+++ b/pkg/fetcher/definition_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"github.com/kyma-incubator/octopus/pkg/humanerr"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 
@@ -42,21 +41,21 @@ func TestFindMatching(t *testing.T) {
 		// GIVEN
 		testA := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-a",
 				Namespace: "test-a",
 			},
 		}
 		testB := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-b",
 				Namespace: "test-b",
 			},
 		}
 		testC := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-c",
 				Namespace: "test-c",
 			},
@@ -95,7 +94,7 @@ func TestFindMatching(t *testing.T) {
 		// GIVEN
 		testA := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-a",
 				Namespace: "test-a",
 				Labels: map[string]string{
@@ -105,7 +104,7 @@ func TestFindMatching(t *testing.T) {
 		}
 		testB := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-b",
 				Namespace: "test-b",
 				Labels: map[string]string{
@@ -115,7 +114,7 @@ func TestFindMatching(t *testing.T) {
 		}
 		testC := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-c",
 				Namespace: "test-c",
 				Labels: map[string]string{
@@ -157,7 +156,7 @@ func TestFindMatching(t *testing.T) {
 		// GIVEN
 		testA := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-a",
 				Namespace: "test-a",
 				Labels: map[string]string{
@@ -167,7 +166,7 @@ func TestFindMatching(t *testing.T) {
 		}
 		testB := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-b",
 				Namespace: "test-b",
 				Labels: map[string]string{
@@ -177,7 +176,7 @@ func TestFindMatching(t *testing.T) {
 		}
 		testC := &v1alpha1.TestDefinition{
 			ObjectMeta: v1.ObjectMeta{
-				UID:       uuid.NewUUID(),
+				UID:       "test-uid",
 				Name:      "test-c",
 				Namespace: "test-c",
 				Labels: map[string]string{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- `matchLabels` in CTS changed to `matchLabelExpressions` and uses k8s syntax for label filtering
- definition service filters TDs by labels
- definition service ensures that unique TDs are returned 
 - sample added 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #7 
